### PR TITLE
 …

### DIFF
--- a/azure/aks/infrastructure/sql.tf
+++ b/azure/aks/infrastructure/sql.tf
@@ -50,7 +50,7 @@ resource "azurerm_mysql_flexible_server_configuration" "max_allowed_packet" {
 }
 
 resource "azurerm_mysql_flexible_database" "mysql" {
-  name                = "ckeditorcs"
+  name                = "cs-on-premises"
   resource_group_name = azurerm_resource_group.resource_group.name
   server_name         = azurerm_mysql_flexible_server.mysql.name
   charset             = "utf8"

--- a/kubernetes/helm/ckeditor-cs/templates/server/ingress.yaml
+++ b/kubernetes/helm/ckeditor-cs/templates/server/ingress.yaml
@@ -11,6 +11,9 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if and .Values.server.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.server.ingress.className }}
+  {{- end }}
 spec:
   {{- if .Values.server.ingress.tls }}
   tls:

--- a/kubernetes/helm/ckeditor-cs/values.yaml
+++ b/kubernetes/helm/ckeditor-cs/values.yaml
@@ -65,13 +65,14 @@ server:
   ingress:
     ## If true will create ingress rule to expose collaboration server from cluster
     enabled: false
+    className: ""
     annotations:
       {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
       # nginx.ingress.kubernetes.io/proxy-body-size: 10m
       # nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-      # nginx.ingress.kubernetes.io/proxy-send-timeout: "3600
+      # nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     hosts:
       - host: ckeditor-cs.organization.test
         paths:


### PR DESCRIPTION
- add IngressClass to the template as kubernetes.io/ingress.class is deprecated since k8s v1.22+
- fix name of default database, so it matches the config from helm deployment (terraform variable mysql_database from service subdir)
- fix missing ending quote for commented out annotation.