### PR TITLE
docs: Replace CKEditor Ecosystem Dashboard with CKEditor Customer Portal.

### DIFF
--- a/aws/ecs/README.md
+++ b/aws/ecs/README.md
@@ -37,13 +37,13 @@ environments_management_secret_key = ""
 
 Note:
 - The `image_version` property should be set to the version of CKEditor Collaboration Server On-Premises image that you want to run. By default, the module uses the CKEditor Collaboration Server On-Premises with the "latest" tag. If you are using this module for a production environment, it's strongly recommended to change the container image tag to a numeric representation of the version you want to use. Refer to https://ckeditor.com/docs/cs/latest/onpremises/cs-onpremises/changelog.html for the list of currently available versions.
-- The `license_key` property can be found in [CKEditor Ecosystem Dashboard](https://dashboard.ckeditor.com/) in your CKEditor Collaboration Server On-Premises subscription page.
-- The `docker_token` property can be found in the CKEditor Ecosystem Dashboard in your CKEditor Collaboration Server On-Premises subscription page in the *Download token* section. If you do not see any tokens, you can create them with the *Create new token* button.
+- The `license_key` property can be found in [CKEditor Customer Portal](https://portal.ckeditor.com/) in your CKEditor Collaboration Server On-Premises subscription page.
+- The `docker_token` property can be found in the CKEditor Customer Portal in your CKEditor Collaboration Server On-Premises subscription page in the *Download token* section. If you do not see any tokens, you can create them with the *Create new token* button.
 - The `environments_management_secret_key` property is your password, which is used to access the Collaboration Server On-Premises [management panel](https://ckeditor.com/docs/cs/latest/onpremises/cs-onpremises/management.html)
 
-4. You can change the AWS region in which the resources will be created in `aws/ecs/main.tf`. Refer to the `aws/ecs/cs-on-premises/variables.tf` file to see which properties of the application can be optionally configured in the module.
+1. You can change the AWS region in which the resources will be created in `aws/ecs/main.tf`. Refer to the `aws/ecs/cs-on-premises/variables.tf` file to see which properties of the application can be optionally configured in the module.
 
-5. Create all required resources:
+2. Create all required resources:
 ```
 terraform apply
 ```

--- a/aws/ecs/cs-on-premises/secrets.tf
+++ b/aws/ecs/cs-on-premises/secrets.tf
@@ -1,6 +1,6 @@
 resource "aws_secretsmanager_secret" "license_key" {
   name        = "cs-on-premises-license-key"
-  description = "The license_key can be found in CKEditor Ecosystem Dashboard in your CKEditor Collaboration Server On-Premises subscription page"
+  description = "The license_key can be found in CKEditor Customer Portal in your CKEditor Collaboration Server On-Premises subscription page"
 
   recovery_window_in_days = 0
 }
@@ -12,7 +12,7 @@ resource "aws_secretsmanager_secret_version" "license_key" {
 
 resource "aws_secretsmanager_secret" "docker_token" {
   name        = "cs-on-premises-docker-token"
-  description = "The docker_token can be found in CKEditor Ecosystem Dashboard in your CKEditor Collaboration Server On-Premises subscription page in the Download token section. If you do not see any tokens, you can create them with the `Create new token` button."
+  description = "The docker_token can be found in CKEditor Customer Portal in your CKEditor Collaboration Server On-Premises subscription page in the Download token section. If you do not see any tokens, you can create them with the `Create new token` button."
 
   recovery_window_in_days = 0
 }
@@ -44,7 +44,7 @@ resource "random_string" "database_password" {
 
 resource "aws_secretsmanager_secret" "database_password" {
   name        = "cs-on-premises-database-password"
-  description = "The license_key can be found in CKEditor Ecosystem Dashboard in your CKEditor Collaboration Server On-Premises subscription page"
+  description = "The license_key can be found in CKEditor Customer Portal in your CKEditor Collaboration Server On-Premises subscription page"
 
   recovery_window_in_days = 0
 }

--- a/azure/aks/service/variables.tf
+++ b/azure/aks/service/variables.tf
@@ -11,7 +11,7 @@ variable "docker_username" {
 }
 
 variable "docker_token" {
-  description = "The `docker_token` can be found in CKEditor Ecosystem Dashboard in your CKEditor Collaboration Server On-Premises subscription page in the *Download token* section. If you do not see any tokens, you can create them with the *Create new token* button."
+  description = "The `docker_token` can be found in CKEditor Customer Portal in your CKEditor Collaboration Server On-Premises subscription page in the *Download token* section. If you do not see any tokens, you can create them with the *Create new token* button."
   type        = string
 }
 

--- a/quick-start/README.md
+++ b/quick-start/README.md
@@ -43,8 +43,8 @@ cd ckeditor-cs-on-premises-infrastructure/quick-start && npm install
 node setup.js --license_key="YOUR_LICENSE_KEY" --docker_token="YOUR_DOCKER_DOWNLOAD_TOKEN" --env_secret="YOUR_ENVIRONMENT_SECRET"
 ```
 Where to find your own credentials:
-- The `license_key` can be found in [CKEditor Ecosystem Dashboard](https://dashboard.ckeditor.com/) in your CKEditor Collaboration Server On-Premises subscription page.
-- The `docker_token` can be found in CKEditor Ecosystem Dashboard in your CKEditor Collaboration Server On-Premises subscription page in the *Download token* section. If you do not see any tokens, you can create them with the *Create new token* button.
+- The `license_key` can be found in [CKEditor Customer Portal](https://portal.ckeditor.com/) in your CKEditor Collaboration Server On-Premises subscription page.
+- The `docker_token` can be found in CKEditor Customer Portal in your CKEditor Collaboration Server On-Premises subscription page in the *Download token* section. If you do not see any tokens, you can create them with the *Create new token* button.
 - The `env_secret` is your password, that will be used to access the Collaboration Server On-Premises [management panel](https://ckeditor.com/docs/cs/latest/onpremises/cs-onpremises/management.html)
 
 

--- a/quick-start/utils/errors.json
+++ b/quick-start/utils/errors.json
@@ -9,7 +9,7 @@
    "wrongToken": "Could not authorize to docker registry using the provided Docker Download Token.",
    "containersTimeout": "Timeout during docker containers startup. Check log.txt for details about errors. If you cannot resolve this issue on your own, please contact our support team.",
    "wrongLicense": "Could not create a On-Premises docker container using the provided License Key.",
-   "licenseKeyDescription": "\nYou can find your License Key in the CKEditor Ecosystem Dashboard inside your CKEditor Collaboration Server On-Premises subscription page.",
-   "dockerTokenDescription": "\nYou can find your Docker Download Token in the CKEditor Ecosystem Dashboard inside your CKEditor Collaboration Server On-Premises subscription page.",
+   "licenseKeyDescription": "\nYou can find your License Key in the CKEditor Customer Portal inside your CKEditor Collaboration Server On-Premises subscription page.",
+   "dockerTokenDescription": "\nYou can find your Docker Download Token in the CKEditor Customer Portal inside your CKEditor Collaboration Server On-Premises subscription page.",
    "envSecretDescription": "\nThe Environment Secret is used as a password for the Cloud Services Management Panel."
 }


### PR DESCRIPTION
The old CKEditor Dashboard has been replaced with a Customer Portal. 